### PR TITLE
docs: mention SinkRotating in features and how-it-works

### DIFF
--- a/components/HowItWorks.tsx
+++ b/components/HowItWorks.tsx
@@ -284,8 +284,8 @@ export default function HowItWorks() {
 
         <div className="flex items-center text-[0.9rem] text-tan opacity-80 mb-4 mx-20">
           <p>
-            For each response, the selected Sink (or default stderr stream)
-            writes JSON
+            For each response, the selected Sink (stderr, file, rotating log,
+            named pipe, or custom) writes JSON
           </p>
         </div>
 

--- a/data/features.tsx
+++ b/data/features.tsx
@@ -17,7 +17,7 @@ export const features: {
     icon: "\uD83D\uDD0C",
     title: "Pluggable Sinks",
     description:
-      "Stream captured traffic to files, named pipes, stdout, or your own custom sink.",
+      "Stream captured traffic to files, rotating log directories, named pipes, stdout, or your own custom sink.",
   },
   {
     icon: "\uD83C\uDFAD",


### PR DESCRIPTION
References rotating log directories alongside existing sink types now that `SinkRotating` has shipped in both shuntly-py and shuntly-ts.

Two small changes:
- **features.tsx**: "Pluggable Sinks" description now includes "rotating log directories"
- **HowItWorks.tsx**: Sink description expanded to list all sink types